### PR TITLE
Use mbedtls's zeroize function instead of standard memset to wipe enc…

### DIFF
--- a/include/cecies/constants.h
+++ b/include/cecies/constants.h
@@ -30,7 +30,12 @@ extern "C" {
 /**
  * The version number of this CECIES implementation.
  */
-#define CECIES_VERSION 211
+#define CECIES_VERSION 212
+
+/**
+ * The version number of this CECIES implementation (nicely-formatted string).
+ */
+#define CECIES_VERSION_STR "2.1.2"
 
 /**
  * Key size (in bytes) of an X25519 key (both public and private key have the same length).

--- a/src/decrypt.c
+++ b/src/decrypt.c
@@ -238,13 +238,13 @@ exit:
     mbedtls_ecp_point_free(&R);
     mbedtls_ecp_point_free(&S);
 
-    memset(iv, 0x00, 16);
-    memset(salt, 0x00, 32);
-    memset(aes_key, 0x00, 32);
-    memset(R_bytes, 0x00, sizeof(R_bytes));
-    memset(S_bytes, 0x00, sizeof(S_bytes));
-    memset(&private_key, 0x00, sizeof(private_key));
-    memset(private_key_bytes, 0x00, sizeof(private_key_bytes));
+    mbedtls_platform_zeroize(iv, 16);
+    mbedtls_platform_zeroize(salt, 32);
+    mbedtls_platform_zeroize(aes_key, 32);
+    mbedtls_platform_zeroize(R_bytes, sizeof(R_bytes));
+    mbedtls_platform_zeroize(S_bytes, sizeof(S_bytes));
+    mbedtls_platform_zeroize(&private_key, sizeof(private_key));
+    mbedtls_platform_zeroize(private_key_bytes, sizeof(private_key_bytes));
 
     if (encrypted_data_base64)
     {

--- a/src/encrypt.c
+++ b/src/encrypt.c
@@ -270,12 +270,12 @@ exit:
     mbedtls_ecp_point_free(&S);
     mbedtls_ecp_point_free(&QA);
 
-    memset(iv, 0x00, sizeof(iv));
-    memset(salt, 0x00, sizeof(salt));
-    memset(pers, 0x00, sizeof(pers));
-    memset(aes_key, 0x00, sizeof(aes_key));
-    memset(S_bytes, 0x00, sizeof(S_bytes));
-    memset(R_bytes, 0x00, sizeof(R_bytes));
+    mbedtls_platform_zeroize(iv, sizeof(iv));
+    mbedtls_platform_zeroize(salt, sizeof(salt));
+    mbedtls_platform_zeroize(pers, sizeof(pers));
+    mbedtls_platform_zeroize(aes_key, sizeof(aes_key));
+    mbedtls_platform_zeroize(S_bytes, sizeof(S_bytes));
+    mbedtls_platform_zeroize(R_bytes, sizeof(R_bytes));
 
     return (ret);
 }

--- a/src/keygen.c
+++ b/src/keygen.c
@@ -20,6 +20,7 @@
 #include <mbedtls/base64.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/ctr_drbg.h>
+#include <mbedtls/platform_util.h>
 
 #include "cecies/guid.h"
 #include "cecies/keygen.h"
@@ -50,8 +51,8 @@ int cecies_generate_curve25519_keypair(cecies_curve25519_keypair* output, const 
     unsigned char pubkeybuf[32];
     size_t prvkeybuflen = 0, pubkeybuflen = 0;
 
-    memset(prvkeybuf, 0x00, sizeof(prvkeybuf));
-    memset(pubkeybuf, 0x00, sizeof(pubkeybuf));
+    mbedtls_platform_zeroize(prvkeybuf, sizeof(prvkeybuf));
+    mbedtls_platform_zeroize(pubkeybuf, sizeof(pubkeybuf));
 
     unsigned char pers[256];
     cecies_dev_urandom(pers, 128);
@@ -145,9 +146,9 @@ exit:
     mbedtls_mpi_free(&r);
     mbedtls_ecp_point_free(&R);
 
-    memset(pers, 0x00, sizeof(pers));
-    memset(prvkeybuf, 0x00, sizeof(prvkeybuf));
-    memset(pubkeybuf, 0x00, sizeof(pubkeybuf));
+    mbedtls_platform_zeroize(pers, sizeof(pers));
+    mbedtls_platform_zeroize(prvkeybuf, sizeof(prvkeybuf));
+    mbedtls_platform_zeroize(pubkeybuf, sizeof(pubkeybuf));
 
     return (ret);
 }
@@ -178,8 +179,8 @@ int cecies_generate_curve448_keypair(cecies_curve448_keypair* output, const unsi
     unsigned char pubkeybuf[56];
     size_t prvkeybuflen = 0, pubkeybuflen = 0;
 
-    memset(prvkeybuf, 0x00, sizeof(prvkeybuf));
-    memset(pubkeybuf, 0x00, sizeof(pubkeybuf));
+    mbedtls_platform_zeroize(prvkeybuf, sizeof(prvkeybuf));
+    mbedtls_platform_zeroize(pubkeybuf, sizeof(pubkeybuf));
 
     unsigned char pers[256];
     cecies_dev_urandom(pers, 128);
@@ -273,9 +274,9 @@ exit:
     mbedtls_mpi_free(&r);
     mbedtls_ecp_point_free(&R);
 
-    memset(pers, 0x00, sizeof(pers));
-    memset(prvkeybuf, 0x00, sizeof(prvkeybuf));
-    memset(pubkeybuf, 0x00, sizeof(pubkeybuf));
+    mbedtls_platform_zeroize(pers, sizeof(pers));
+    mbedtls_platform_zeroize(prvkeybuf, sizeof(prvkeybuf));
+    mbedtls_platform_zeroize(pubkeybuf, sizeof(pubkeybuf));
 
     return (ret);
 }


### PR DESCRIPTION
Use MbedTLS's own per-platform zeroize function instead of the standard memset for cleaning up/wiping memory inside encrypt/decrypt functions.